### PR TITLE
Changed Minecraft dependency from "1.17.x" to ">=1.17.1".

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,18 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.14
-	loader_version=0.11.6
+	minecraft_version=1.18.2
+	yarn_mappings=1.18.2+build.2
+	loader_version=0.13.3
+
+#Fabric api
+	fabric_version=0.47.10+1.18.2
 
 # Mod Properties
-	mod_version = 1.1.0
+	mod_version = 1.2.0
 	maven_group = com.rebelkeithy.extendedarmorbars
 	archives_base_name = extended-armor-bars
 
 # Dependencies
-	fabric_version=0.37.0+1.17
-	modmenu_version=2.0.4
-	cloth_config_version=5.0.38
+	modmenu_version=3.1.0
+	cloth_config_version=6.2.57

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": ">=1.17.1",
+    "minecraft": ">=1.18",
     "java": ">=16"
   },
   "suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,8 +34,8 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": ">=1.18",
-    "java": ">=16"
+    "minecraft": ">=1.18.2",
+    "java": ">=17"
   },
   "suggests": {
     "another-mod": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.17.x",
+    "minecraft": ">=1.17.1",
     "java": ">=16"
   },
   "suggests": {


### PR DESCRIPTION
Haven't check the code for issue with 1.18+, but it does seem to work in 1.18.1 after some play testing. I'm not sure if you are still maintaining this mod or not, but this would help the people waiting for a 1.18 release.