### PR TITLE
Use correct OS-specific file separator and use non-generic config name

### DIFF
--- a/src/main/java/com/rebelkeithy/extendedarmorbars/ToughnessBar.java
+++ b/src/main/java/com/rebelkeithy/extendedarmorbars/ToughnessBar.java
@@ -15,7 +15,7 @@ import net.minecraft.util.math.MathHelper;
 public class ToughnessBar implements ModInitializer {
 
 	public static final String MOD_ID = "extendedarmorbars";
-	private static final String CONFIG_FILE = "config.json";
+	private static final String CONFIG_FILE = MOD_ID + ".json";
 	private static final Identifier ARMOR = new Identifier(MOD_ID, "textures/gui/armor.png");
 	private static final Identifier TOUGHNESS = new Identifier(MOD_ID, "textures/gui/toughness.png");
 

--- a/src/main/java/com/rebelkeithy/extendedarmorbars/config/ConfigLoader.java
+++ b/src/main/java/com/rebelkeithy/extendedarmorbars/config/ConfigLoader.java
@@ -5,9 +5,10 @@ import com.google.gson.GsonBuilder;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.*;
+import java.nio.file.FileSystems;
 
 public class ConfigLoader {
-    private static final String CONFIG_DIR = FabricLoader.getInstance().getConfigDir() + "\\";
+    private static final String CONFIG_DIR = FabricLoader.getInstance().getConfigDir() + FileSystems.getDefault().getSeparator();
 
     public Config loadConfigFile(String filename) {
         Config config;


### PR DESCRIPTION
Closes #3 