### PR TITLE
More support of Linux filesystem

### DIFF
--- a/src/main/java/com/rebelkeithy/extendedarmorbars/config/ConfigLoader.java
+++ b/src/main/java/com/rebelkeithy/extendedarmorbars/config/ConfigLoader.java
@@ -7,7 +7,7 @@ import net.fabricmc.loader.api.FabricLoader;
 import java.io.*;
 
 public class ConfigLoader {
-    private static final String CONFIG_DIR = FabricLoader.getInstance().getConfigDir() + "\\";
+    private static final String CONFIG_DIR = FabricLoader.getInstance().getConfigDir() + "/";
 
     public Config loadConfigFile(String filename) {
         Config config;


### PR DESCRIPTION
Fix a bug where config appears in "<configdir>/../config\config.json" instead of "<configdir>/config.json", because, on Linux the directory separator is exclusive "/" and not "\". I think this might also affect MacOS.